### PR TITLE
ds1 fixes

### DIFF
--- a/docs/source/main/commands.rst
+++ b/docs/source/main/commands.rst
@@ -339,6 +339,35 @@ The ``++savecfg`` command will save the following current parameter values: ``ad
 :Modes: controller, device
 :Syntax: ``++savecfg``
 
+``++settle_r++``
+++++++++++++++++
+
+This command configures a settling time between the bus providing data to read
+(DAV active, NRFD asserted), and actually reading the data from the bus. The
+time is in microseconds, valid range between 0 (no delay) and 16000.
+
+If the command is issued without a parameter, the current read settling time
+is returned.
+
+:Modes: controller, device
+:Syntax: ``++settle_r <time>``
+	 where <time> is a decimal number between 0 and 16000.
+
+
+``++settle_s++``
+++++++++++++++++
+
+This command configures a settling time between delivering the data to the
+bus, and asserting the DAV signal. The time is in microseconds, valid range
+between 0 (no delay) and 16000.
+
+If the command is issued without a parameter, the current read settling time
+is returned.
+
+:Modes: controller, device
+:Syntax: ``++settle_s <time>``
+	 where <time> is a decimal number between 0 and 16000.
+
 
 ``++spoll``
 +++++++++++

--- a/docs/source/main/commands.rst
+++ b/docs/source/main/commands.rst
@@ -361,7 +361,7 @@ This command configures a settling time between delivering the data to the
 bus, and asserting the DAV signal. The time is in microseconds, valid range
 between 0 (no delay) and 16000.
 
-If the command is issued without a parameter, the current read settling time
+If the command is issued without a parameter, the current send settling time
 is returned.
 
 :Modes: controller, device

--- a/src/AR488/AR488.ino
+++ b/src/AR488/AR488.ino
@@ -220,6 +220,13 @@ GPIBbus gpibBus;
 // Verbose mode
 bool isVerb = false;
 
+// Debug mode
+bool isDebug = false;
+
+// Adjustable settling times
+uint16_t settle_r_time = 0; // receive settle time (in us)
+uint16_t settle_s_time = 0; // send settle time (in us)
+
 // CR/LF terminated line ready to process
 uint8_t lnRdy = 0;      
 
@@ -830,8 +837,11 @@ static cmdRec cmdHidx [] = {
   { "unt",         2, (void(*)(char*)) untalk_h    },
   { "ver",         3, ver_h       },
   { "verbose",     3, (void(*)(char*)) verb_h    },
-  { "xdiag",       3, xdiag_h     }
+  { "xdiag",       3, xdiag_h     },
 //  { "xonxoff",     3, xonxoff_h   }
+  { "debug",       3, (void(*)(char*)) debug_h    },
+  { "settle_r",    3, settler_h     },
+  { "settle_s",    3, settles_h     },
 };
 
 
@@ -1142,6 +1152,38 @@ void rtmo_h(char *params) {
     }
   } else {
     dataPort.println(gpibBus.cfg.rtmo);
+  }
+}
+
+/***** Show or set receive settle time (in us) *****/
+void settler_h(char *params) {
+  uint16_t val;
+  if (params != NULL) {
+    if (notInRange(params, 0, 32000, val)) return;
+    settle_r_time = val;
+    if (isVerb) {
+      dataPort.print(F("Set [receive settle time] to: "));
+      dataPort.print(val);
+      dataPort.println(F(" us"));
+    }
+  } else {
+    dataPort.println(settle_r_time);
+  }
+}
+
+/***** Show or set send settle time (in us) *****/
+void settles_h(char *params) {
+  uint16_t val;
+  if (params != NULL) {
+    if (notInRange(params, 0, 32000, val)) return;
+    settle_s_time = val;
+    if (isVerb) {
+      dataPort.print(F("Set [send settle time] to: "));
+      dataPort.print(val);
+      dataPort.println(F(" us"));
+    }
+  } else {
+    dataPort.println(settle_s_time);
   }
 }
 
@@ -1837,6 +1879,12 @@ void verb_h() {
   dataPort.println(isVerb ? "ON" : "OFF");
 }
 
+/***** Enable debug mode 0=OFF; 1=ON *****/
+void debug_h() {
+  isDebug = !isDebug;
+  dataPort.print("Debug: ");
+  dataPort.println(isDebug ? "ON" : "OFF");
+}
 
 /***** Set version string *****/
 /* Replace the standard AR488 version string with something else

--- a/src/AR488/AR488.ino
+++ b/src/AR488/AR488.ino
@@ -223,10 +223,6 @@ bool isVerb = false;
 // Debug mode
 bool isDebug = false;
 
-// Adjustable settling times
-uint16_t settle_r_time = 0; // receive settle time (in us)
-uint16_t settle_s_time = 0; // send settle time (in us)
-
 // CR/LF terminated line ready to process
 uint8_t lnRdy = 0;      
 
@@ -1160,14 +1156,14 @@ void settler_h(char *params) {
   uint16_t val;
   if (params != NULL) {
     if (notInRange(params, 0, 32000, val)) return;
-    settle_r_time = val;
+    gpibBus.setSettleRTime(val);
     if (isVerb) {
       dataPort.print(F("Set [receive settle time] to: "));
       dataPort.print(val);
       dataPort.println(F(" us"));
     }
   } else {
-    dataPort.println(settle_r_time);
+    dataPort.println(gpibBus.getSettleRTime());
   }
 }
 
@@ -1176,14 +1172,14 @@ void settles_h(char *params) {
   uint16_t val;
   if (params != NULL) {
     if (notInRange(params, 0, 32000, val)) return;
-    settle_s_time = val;
+    gpibBus.setSettleSTime(val);
     if (isVerb) {
       dataPort.print(F("Set [send settle time] to: "));
       dataPort.print(val);
       dataPort.println(F(" us"));
     }
   } else {
-    dataPort.println(settle_s_time);
+    dataPort.println(gpibBus.getSettleSTime());
   }
 }
 

--- a/src/AR488/AR488.ino
+++ b/src/AR488/AR488.ino
@@ -164,6 +164,8 @@ static const char cmdHelp[] PROGMEM = {
   "read_tmo_ms:P Read timeout specified between 1 - 3000 milliseconds\n"
   "rst:P Reset the controller\n"
   "savecfg:P Save configration\n"
+  "settle_r:P Settling time on read operation, between 0 and 16000 microseconds\n"
+  "settle_s:P Settling time on send operation, between 0 and 16000 microseconds\n"
   "spoll:P Serial poll the addressed host or all instruments\n"
   "srq:P Return status of srq signal (1-srq asserted/0-srq not asserted)\n"
   "status:P Set the status byte to be returned on being polled (bit 6 = RQS, i.e SRQ asserted)\n"

--- a/src/AR488/AR488.ino
+++ b/src/AR488/AR488.ino
@@ -222,9 +222,6 @@ GPIBbus gpibBus;
 // Verbose mode
 bool isVerb = false;
 
-// Debug mode
-bool isDebug = false;
-
 // CR/LF terminated line ready to process
 uint8_t lnRdy = 0;      
 
@@ -837,7 +834,6 @@ static cmdRec cmdHidx [] = {
   { "verbose",     3, (void(*)(char*)) verb_h    },
   { "xdiag",       3, xdiag_h     },
 //  { "xonxoff",     3, xonxoff_h   }
-  { "debug",       3, (void(*)(char*)) debug_h    },
   { "settle_r",    3, settler_h     },
   { "settle_s",    3, settles_h     },
 };
@@ -1875,13 +1871,6 @@ void verb_h() {
   isVerb = !isVerb;
   dataPort.print("Verbose: ");
   dataPort.println(isVerb ? "ON" : "OFF");
-}
-
-/***** Enable debug mode 0=OFF; 1=ON *****/
-void debug_h() {
-  isDebug = !isDebug;
-  dataPort.print("Debug: ");
-  dataPort.println(isDebug ? "ON" : "OFF");
 }
 
 /***** Set version string *****/

--- a/src/AR488/AR488_GPIBbus.cpp
+++ b/src/AR488/AR488_GPIBbus.cpp
@@ -498,13 +498,6 @@ bool GPIBbus::sendCmd(uint8_t cmdByte) {
   state = writeByte(cmdByte, NO_EOI);
   if (state == HANDSHAKE_COMPLETE) return OK;
 
-  if (isDebug)
-  {
-    char buffer[40];
-    sprintf(buffer, "Failed to send command %02X to device ", cmdByte);
-    dataPort.println(buffer);
-  }
-
 #if defined(DEBUG_GPIBbus_RECEIVE) || defined(DEBUG_GPIBbus_SEND)
   char buffer[40];
   sprintf(buffer, "Failed to send command %02X to device ", cmdByte);
@@ -575,16 +568,12 @@ bool GPIBbus::receiveData(Stream &dataStream, bool detectEoi, bool detectEndByte
     // txBreak > 0 indicates break condition
     if (txBreak)
     {
-      if (isDebug)
-        dataPort.println(F("receiveData: txBreak"));
       break;
     }
 
     // ATN asserted
     if (isAsserted(ATN_PIN))
     {
-      if (isDebug)
-        dataPort.println(F("receiveData: isAsserted(ATN_PIN)"));
       break;
     }
 
@@ -611,8 +600,6 @@ bool GPIBbus::receiveData(Stream &dataStream, bool detectEoi, bool detectEndByte
       if (readWithEoi) {
         if (eoiDetected)
         {
-          if (isDebug)
-            dataPort.println(F("receiveData: eoiDetected"));
           break;
         }
       } else {
@@ -620,15 +607,11 @@ bool GPIBbus::receiveData(Stream &dataStream, bool detectEoi, bool detectEndByte
         if (detectEndByte) {
           if (bytes[0] == endByte)
           {
-            if (isDebug)
-              dataPort.println(F("receiveData: endByte"));
             break;
           }
         } else {
           if (isTerminatorDetected(bytes, eor))
           {
-            if (isDebug)
-              dataPort.println(F("receiveData: isTerminatorDetected()"));
             break;
           }
         }
@@ -641,20 +624,6 @@ bool GPIBbus::receiveData(Stream &dataStream, bool detectEoi, bool detectEndByte
       // Stop (error or timeout)
       break;
     }
-  }
-
-  if (isDebug)
-  {
-    if(state == IFC_ASSERTED)
-      dataPort.println(F("receiveData: IFC_ASSERTED"));
-    else if(state == ATN_ASSERTED)
-      dataPort.println(F("receiveData: ATN_ASSERTED"));
-    else if(state != HANDSHAKE_COMPLETE)
-      {
-        char buffer[60];
-        sprintf(buffer, "receiveData: state: %d eoiDetected: %d", state, eoiDetected);
-        dataPort.println(buffer);
-      }
   }
 
 #ifdef DEBUG_GPIBbus_RECEIVE
@@ -718,13 +687,6 @@ bool GPIBbus::receiveData(Stream &dataStream, bool detectEoi, bool detectEndByte
 
 /***** Send a series of characters as data to the GPIB bus *****/
 void GPIBbus::sendData(char *data, uint8_t dsize) {
-
-  // should never happen
-  if (dsize == 0)
-  {
-    if (isDebug)
-      dataPort.println(F("dsize == 0"));
-  }
 
   //  bool err = false;
   uint8_t tc;
@@ -1173,8 +1135,6 @@ enum gpibHandshakeStates GPIBbus::readByte(uint8_t *db, bool readWithEoi, bool *
   {
     assertSignal(NRFD_BIT);
     assertSignal(NDAC_BIT);
-    if (isDebug)
-      dataPort.println(F("readByte: assert NRFD and NDAC"));
   }
 
   // Otherwise return stage
@@ -1293,12 +1253,6 @@ enum gpibHandshakeStates GPIBbus::writeByte(uint8_t db, bool isLastByte) {
     return gpibState;
   }
 
-  if (isDebug)
-  {
-    char buffer[40];
-    sprintf(buffer, "Error writeByte(%02X, %d)", db, isLastByte);
-    dataPort.println(buffer);
-  }
   // make sure that data are not considered valid
   clearSignal(DAV_BIT);
 

--- a/src/AR488/AR488_GPIBbus.h
+++ b/src/AR488/AR488_GPIBbus.h
@@ -14,10 +14,6 @@
 
 /***** AR488_GPIBbus.cpp, ver. 0.51.29, 18/03/2024 *****/
 
-extern bool isDebug;
-extern uint16_t settle_r_time; // receive settle time (in us)
-extern uint16_t settle_s_time; // send settle time (in us)
-
 /*********************************************/
 /***** GPIB COMMAND & STATUS DEFINITIONS *****/
 /***** vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv *****/

--- a/src/AR488/AR488_GPIBbus.h
+++ b/src/AR488/AR488_GPIBbus.h
@@ -224,11 +224,20 @@ public:
   bool unAddressDevice();
   bool haveAddressedDevice();
 
+  void setSettleRTime(uint16_t t) { settle_r_time = t; }
+  void setSettleSTime(uint16_t t) { settle_s_time = t; }
+  uint16_t getSettleRTime(void) { return settle_r_time; }
+  uint16_t getSettleSTime(void) { return settle_s_time; }
+
 private:
 
   bool txBreak;  // Signal to break the GPIB transmission
   bool deviceAddressed;
   bool isTerminatorDetected(uint8_t bytes[3], uint8_t eorSequence);
+
+  // Adjustable settling times
+  uint16_t settle_r_time; // receive settle time (in us)
+  uint16_t settle_s_time; // send settle time (in us)
 
   // Interrupt flag for MCP23S17
 #ifdef AR488_MCP23S17

--- a/src/AR488/AR488_GPIBbus.h
+++ b/src/AR488/AR488_GPIBbus.h
@@ -14,6 +14,9 @@
 
 /***** AR488_GPIBbus.cpp, ver. 0.51.29, 18/03/2024 *****/
 
+extern bool isDebug;
+extern uint16_t settle_r_time; // receive settle time (in us)
+extern uint16_t settle_s_time; // send settle time (in us)
 
 /*********************************************/
 /***** GPIB COMMAND & STATUS DEFINITIONS *****/
@@ -116,7 +119,8 @@ enum operatingModes {
 
 
 enum transmitModes {
-  TM_IDLE,
+  TM_CTRL_IDLE, // Dieter
+  TM_DEVICE_IDLE, // Dieter
   TM_RECV,
   TM_SEND
 };

--- a/src/AR488/AR488_GPIBbus.h
+++ b/src/AR488/AR488_GPIBbus.h
@@ -115,8 +115,8 @@ enum operatingModes {
 
 
 enum transmitModes {
-  TM_CTRL_IDLE, // Dieter
-  TM_DEVICE_IDLE, // Dieter
+  TM_CTRL_IDLE,
+  TM_DEVICE_IDLE,
   TM_RECV,
   TM_SEND
 };


### PR DESCRIPTION
Various fixes for GPIB handling from ds1:

* split `TM_IDLE` into `TM_CTRL_IDLE` and `TM_DEVICE_IDLE`
* allow for adjustable settling times for read and transmit operations