### PR TITLE
Fixes from Dieter (ds1)

### DIFF
--- a/src/AR488/AR488.ino
+++ b/src/AR488/AR488.ino
@@ -1654,17 +1654,12 @@ void spoll_h(char *params) {
     // No parameters - trigger addressed device only
     addrs[0] = gpibBus.cfg.paddr;
     j = 1;
-  }
-
-  // ALL parameter given?
-  if (strncasecmp(params, "all", 3) == 0) {
+  } else if (strncasecmp(params, "all", 3) == 0) {
+    // ALL parameter given?
     all = true;
     j = 30;
     if (isVerb) dataPort.println(F("Serial poll of all devices requested..."));
-  }
-
-  if (j == 0) {
-
+  } else {
     // Read address parameters into array
     while (j < 15) {
 


### PR DESCRIPTION
Various fixes needed for a working device mode:

* split state `TM_IDLE` into `TM_CTRL_IDLE`, and `TM_DEVICE_IDLE`
* comment the actions taken on the SN7516x interface chips
* implement `settle_r` and `settle_s` command, allow for configurable settling times
